### PR TITLE
Fix javadoc issue

### DIFF
--- a/src/main/java/com/github/windpapi4j/WinDPAPI.java
+++ b/src/main/java/com/github/windpapi4j/WinDPAPI.java
@@ -114,7 +114,7 @@ import java.util.List;
  *
  *
  *
- * <h2>Sample Code</h2>
+ * <h1>Sample Code</h1>
  *
  *
  * <pre><code>


### PR DESCRIPTION
When parsed as Javadocs, the H2 tag requires a prior H1 tag.  This fixes a small Javadoc bug.